### PR TITLE
Support RN 0.30 (Android), Rename ZDCSessionConfig -> ZDCConfig (IOS)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ repositories {
 
 dependencies {
     compile "com.facebook.react:react-native:+"
-    compile group: 'com.zopim.android', name: 'sdk', version: '1.2.0.1'
+    compile group: 'com.zopim.android', name: 'sdk', version: '1.3.0.1'
 }

--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -2,19 +2,21 @@ package com.taskrabbit.zendesk;
 
 import android.app.Activity;
 import android.content.Intent;
-import com.facebook.react.bridge.*;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.zopim.android.sdk.api.ZopimChat;
 import com.zopim.android.sdk.model.VisitorInfo;
 import com.zopim.android.sdk.prechat.ZopimChatActivity;
 
 public class RNZendeskChatModule extends ReactContextBaseJavaModule {
     private ReactContext mReactContext;
-    private Activity mActivity;
 
-    public RNZendeskChatModule(ReactApplicationContext reactContext, Activity activity) {
+    public RNZendeskChatModule(ReactApplicationContext reactContext) {
         super(reactContext);
-
-        mActivity = activity;
         mReactContext = reactContext;
     }
 
@@ -45,6 +47,9 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void startChat(ReadableMap options) {
         setVisitorInfo(options);
-        mActivity.startActivity(new Intent(mReactContext, ZopimChatActivity.class));
+        Activity activity = getCurrentActivity();
+        if (activity != null) {
+            activity.startActivity(new Intent(mReactContext, ZopimChatActivity.class));
+        }
     }
 }

--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatPackage.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatPackage.java
@@ -1,7 +1,5 @@
 package com.taskrabbit.zendesk;
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -13,18 +11,13 @@ import java.util.Collections;
 import java.util.List;
 
 public class RNZendeskChatPackage implements ReactPackage {
-    Activity mActivity;
-
-    public RNZendeskChatPackage(Activity activity) {
-        mActivity = activity;
-    }
 
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
-        modules.add(new RNZendeskChatModule(reactContext, mActivity));
+        modules.add(new RNZendeskChatModule(reactContext));
         return modules;
     }
 

--- a/ios/RNZendeskChatModule.m
+++ b/ios/RNZendeskChatModule.m
@@ -32,7 +32,7 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
   [self setVisitorInfo:options];
 
   dispatch_sync(dispatch_get_main_queue(), ^{
-    [ZDCChat startChat:^(ZDCSessionConfig *config) {
+    [ZDCChat startChat:^(ZDCConfig *config) {
       config.preChatDataRequirements.name       = ZDCPreChatDataRequired;
       config.preChatDataRequirements.email      = ZDCPreChatDataRequired;
       config.preChatDataRequirements.phone      = ZDCPreChatDataRequired;


### PR DESCRIPTION
For Android:

* Updated ZDCChat SDK 1.2.01 -> 1.3.0.1
* Fixes related to RN 0.30

For IOS:
* Rename ZDCSessionConfig -> ZDCConfig

With `ZDCSessionConfig` it throws an error:
```
node_modules/react-native-zendesk-chat/ios/RNZendeskChatModule.m:35:24: error: incompatible block pointer types sending 'int ((^)(void))' to parameter of type 'ZDCConfigBlock' (aka 'void (^)(ZDCConfig *__strong)')
    [ZDCChat startChat:^(ZDCSessionConfig *config) {
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In module 'ZDCChat' imported from node_modules/react-native-zendesk-chat/ios/RNZendeskChatModule.m:10:
ZDCChat.framework/Headers/ZDCChat.h:141:35: note: passing argument to parameter 'sessionConfig' here
+ (void)startChat:(ZDCConfigBlock)sessionConfig;
                                  ^
1 warning and 7 errors generated.
```