### PR TITLE
Expose init method to react

### DIFF
--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -12,6 +12,8 @@ import com.zopim.android.sdk.api.ZopimChat;
 import com.zopim.android.sdk.model.VisitorInfo;
 import com.zopim.android.sdk.prechat.ZopimChatActivity;
 
+import java.lang.String;
+
 public class RNZendeskChatModule extends ReactContextBaseJavaModule {
     private ReactContext mReactContext;
 
@@ -42,6 +44,11 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
         VisitorInfo visitorData = builder.build();
 
         ZopimChat.setVisitorInfo(visitorData);
+    }
+
+    @ReactMethod
+    public void init(String key) {
+        ZopimChat.init(key);
     }
 
     @ReactMethod


### PR DESCRIPTION
We need this function exposed so we can initialize the chat directly from react.
We use different account key for development and for production and it's easier to change this in `env` then in `MainActivity.java`.