### PR TITLE
Update RNZendeskChatPackage.java for supporting react-native v0.47.0

### DIFF
--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatPackage.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatPackage.java
@@ -21,7 +21,6 @@ public class RNZendeskChatPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Removing the @Override annotation for supporting the latest react-native version 0.47.0