### PR TITLE
Add init method for iOS

### DIFF
--- a/ios/RNZendeskChatModule.m
+++ b/ios/RNZendeskChatModule.m
@@ -48,4 +48,8 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
   });
 }
 
+RCT_EXPORT_METHOD(init:(NSString *)zenDeskKey) {
+  [ZDCChat initializeWithAccountKey:zenDeskKey];
+}
+
 @end


### PR DESCRIPTION
Allows you to initialise the zendesk backend via runtime