### PR TITLE
Update build.gradle and add prechat form

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,7 @@
+apply plugin: 'com.android.library'
+
 def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 buildscript {
@@ -8,30 +10,31 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.3'
+    google()
+    classpath 'com.android.tools.build:gradle:3.2.1'
   }
 }
 
-apply plugin: 'com.android.library'
-
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
-    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', "28.0.3")
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 22)
-        versionCode 1
-        versionName "1.0"
+      minSdkVersion safeExtGet('minSdkVersion', 16)
+      targetSdkVersion safeExtGet('targetSdkVersion', 28)
+      versionCode 1
+      versionName "1.0"
     }
 }
 
 repositories {
   mavenCentral()
-  maven { url 'https://zendesk.artifactoryonline.com/zendesk/repo' }
+  jcenter()
+  google()
+  maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
-    compile group: 'com.zopim.android', name: 'sdk', version: '1.4.2'
+  implementation "com.facebook.react:react-native:+"
+  implementation group: 'com.zopim.android', name: 'sdk', version: '1.4.8'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.taskrabbit.zendesk.RNZendeskChat" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.taskrabbit.zendesk" >
 </manifest>

--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.zopim.android.sdk.api.ZopimChat;
+import com.zopim.android.sdk.prechat.PreChatForm;
 import com.zopim.android.sdk.model.VisitorInfo;
 import com.zopim.android.sdk.prechat.ZopimChatActivity;
 
@@ -48,7 +49,16 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void init(String key) {
-        ZopimChat.init(key);
+        PreChatForm defaultPreChat = new PreChatForm.Builder()
+                .name(PreChatForm.Field.REQUIRED)
+                .email(PreChatForm.Field.REQUIRED)
+                .phoneNumber(PreChatForm.Field.REQUIRED)
+                .department(PreChatForm.Field.REQUIRED_EDITABLE)
+                .message(PreChatForm.Field.REQUIRED)
+                .build();
+        ZopimChat.init(key)
+            .preChatForm(defaultPreChat)
+            .build();
     }
 
     @ReactMethod


### PR DESCRIPTION
Updated `build.gradle` to conform with the latest zendesk android sdk.

Added a prechat-form for android to define a more consistent experience for both iOS and Android.

Only issue now is I've hard-coded the requirements for the prechat-form. I did have a initial look into how i could define the same options in iOS to make certain fields optional but did not have the time to follow through on that.