### PR TITLE
Fix email field on `setVisitorInfo` method

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,6 @@ repositories {
 dependencies {
   implementation "com.facebook.react:react-native:+"
 
-  api group: 'com.zendesk', name: 'chat', version: safeExtGet('zendeskChatVersion', '2.2.0')
-  api group: 'com.zendesk', name: 'messaging', version: safeExtGet('zendeskMessagingVersion', '4.3.1')
+  api group: 'com.zendesk', name: 'chat', version: safeExtGet('zendeskChatVersion', '3.1.0')
+  api group: 'com.zendesk', name: 'messaging', version: safeExtGet('zendeskMessagingVersion', '5.1.0')
 }

--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -150,7 +150,7 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
         }
         String email = getStringOrNull(options, "email", "visitorInfo");
         if (email != null) {
-            builder = builder.withEmail(name);
+            builder = builder.withEmail(email);
         }
         String phone = getStringOrNull(options, "phone", "visitorInfo");
         if (phone != null) {


### PR DESCRIPTION
This PR fixes the `setVisitorInfo` method on android that it was using the `name` on the `email` field. The main issue with this was that the `setVisitorInfo` didn't work on Android if you se the user email.

I also took this opportunity to bump the Android SDK to the latest version since it didn't  introduced any breaking changes. More information here: https://developer.zendesk.com/embeddables/docs/chat-sdk-v-2-for-android/release_notes#version-3.1.0