### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNZendeskChat.podspec
+++ b/RNZendeskChat.podspec
@@ -3,20 +3,20 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "RNZendeskChat"
+  s.name         = 'RNZendeskChat'
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "10"
-  s.source       = { :git => "https://github.com/taskrabbit/react-native-zendesk-chat.git", :tag => "v#{s.version}" }
-  s.source_files = "ios/*.{h,m}"
+  s.platform     = :ios, '10'
+  s.source       = { git: 'https://github.com/taskrabbit/react-native-zendesk-chat.git', tag: "v#{s.version}" }
+  s.source_files = 'ios/*.{h,m}'
   s.static_framework = true
 
   s.framework    = 'Foundation'
   s.framework    = 'UIKit'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'ZendeskChatSDK'
 end


### PR DESCRIPTION
Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. 
This change requires React Native 0.60.2 or newer. 
For more details please check: [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)