### PR TITLE
Fix android visitor info

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ In Xcode, drag and drop `node_modules/react-native-zendesk-chat/RNZendeskChat.m`
 // ...
 
 // Inside the appropriate appDidFinishLaunching method
-[ZDCChat initializeWithAccountKey:@"YOUR_ZENDESK_ACCOUNT_KEY"];
+[ZDCChat initializeWithAccountKey:@"YOUR_ZENDESK_ACCOUNT_KEY" appId:"YOUR_ZENDESK_APP_ID"];
 
 // And access other interesting APIs
 ```
@@ -166,7 +166,7 @@ compile project(':react-native-zendesk-chat')
 // Note: there is a JS method to do this -- prefer doing that! -- This is for advanced users only.
 
 // Call this once in your Activity's bootup lifecycle
-Chat.INSTANCE.init(mReactContext, key);
+Chat.INSTANCE.init(mReactContext, key, appId);
 ```
 
 ## Contributing


### PR DESCRIPTION
According to [this strange comment on the offical Zendesk Forum](https://develop.zendesk.com/hc/en-us/community/posts/360044257813/comments/360014026913) and  [this support post](https://support.zendesk.com/hc/en-us/articles/360055343673), there is an additionnal config to enable visitor info to be shown on the zendesk dashboard.

Also, bump android zendesk dependencies and add zendeskAppId to the init method to match [the last Zendesk Chat SDK v2 documentation](https://developer.zendesk.com/embeddables/docs/chat-sdk-v-2-for-android/getting_started).