### PR TITLE
Android Visitor Info Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ In Xcode, drag and drop `node_modules/react-native-zendesk-chat/RNZendeskChat.m`
 // ...
 
 // Inside the appropriate appDidFinishLaunching method
-[ZDCChat initializeWithAccountKey:@"YOUR_ZENDESK_ACCOUNT_KEY"];
+[ZDCChat initializeWithAccountKey:@"YOUR_ZENDESK_ACCOUNT_KEY" appId:"YOUR_ZENDESK_APP_ID"];
 
 // And access other interesting APIs
 ```
@@ -166,7 +166,7 @@ compile project(':react-native-zendesk-chat')
 // Note: there is a JS method to do this -- prefer doing that! -- This is for advanced users only.
 
 // Call this once in your Activity's bootup lifecycle
-Chat.INSTANCE.init(mReactContext, key);
+Chat.INSTANCE.init(mReactContext, key, appId);
 ```
 
 ## Contributing

--- a/RNZendeskChat.d.ts
+++ b/RNZendeskChat.d.ts
@@ -28,7 +28,13 @@ declare module "react-native-zendesk-chat" {
 		tags?: string[];
 
 		behaviorFlags?: {
-			/** if omitted, the form is enabled */
+			/**
+			 * if omitted, the form is enabled
+			 *
+			 * @warning Android: If you enable preChat form with `required` or `optional` for keys
+			 * 	Then any visitor info you provide statically as VisitorInfoOptions will be ignored.
+			 * 	This is documented upstream here: https://support.zendesk.com/hc/en-us/articles/360055343673
+			 */
 			showPreChatForm?: boolean;
 			/** if omitted, the prompt is enabled */
 			showChatTranscriptPrompt?: boolean;
@@ -38,7 +44,13 @@ declare module "react-native-zendesk-chat" {
 			showAgentAvailability?: boolean;
 		};
 
-		/** If omitted, the preChatForm will be left as default in Zendesk */
+		/**
+		 * If omitted, the preChatForm will be left as default in Zendesk, be explicit if you want control.
+		 *
+		 * @warning Android: If you provide the preChat form with `required` or `optional` for keys
+		 * 	Then any visitor info you provide statically as VisitorInfoOptions will be ignored.
+		 * 	This is documented upstream here: https://support.zendesk.com/hc/en-us/articles/360055343673
+		 */
 		preChatFormOptions?: {
 			/** Should we ask the user for a contact email? */
 			email?: PreChatFormFieldOptionVisibility;

--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -135,11 +135,12 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
     }
 
     private void selectVisitorInfoFieldIfPreChatFormHidden(String key, WritableNativeMap output, ReadableMap input, ReadableMap shouldInclude) {
-        if (!input.hasKey(key)
-            || input.getType(key) != ReadableType.String
-            || (shouldInclude.hasKey(key) && shouldInclude.getType(key) == ReadableType.String && shouldInclude.getString(key) != "hidden") ) {
+        if ((!input.hasKey(key) || input.getType(key) != ReadableType.String)
+            || (shouldInclude.hasKey(key) && shouldInclude.getType(key) == ReadableType.String && !"hidden".equals(shouldInclude.getString(key))) ) {
             return;
         }
+
+        Log.d(TAG, "selectVisitorInfo to set later " + key + " "+ input.getString(key));
         output.putString(key, input.getString(key));
     }
     // }
@@ -349,6 +350,8 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
                     // Add here the code to set the selected visitor info *after* the preChatForm is complete
                     _setVisitorInfo(pendingVisitorInfo);
                     pendingVisitorInfo = null;
+
+                    Log.d(TAG, "Set the VisitorInfo after chat start");
                 } else {
                     // There are few other statuses that you can observe but they are unused in this example
                     Log.d(TAG, "[observerSetup] - ChatSessionUpdate -> (unused) status : " + chatStatus.toString());

--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -32,9 +32,8 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
 
     private ArrayList<String> currentUserTags = new ArrayList();
 
-    private boolean visitorSet = false;
-    private ProfileProvider profileProvider;
-    private VisitorInfo visitorInfo;
+    private ReadableMap pendingVisitorInfo = null;
+    private ObservationScope observationScope = null;
 
     // private class Converters {
     public static ArrayList<String> getArrayListOfStrings(ReadableMap options, String key, String functionHint) {
@@ -134,6 +133,15 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
         }
         return options.getMap(key);
     }
+
+    private void selectVisitorInfoFieldIfPreChatFormHidden(String key, WritableNativeMap output, ReadableMap input, ReadableMap shouldInclude) {
+        if (!input.hasKey(key)
+            || input.getType(key) != ReadableType.String
+            || (shouldInclude.hasKey(key) && shouldInclude.getType(key) == ReadableType.String && shouldInclude.getString(key) != "hidden") ) {
+            return;
+        }
+        output.putString(key, input.getString(key));
+    }
     // }
 
     private ReactContext mReactContext;
@@ -150,31 +158,39 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setVisitorInfo(ReadableMap options) {
+        _setVisitorInfo(options);
+    }
+    private boolean _setVisitorInfo(ReadableMap options) {
+        boolean anyValuesWereSet = false;
         VisitorInfo.Builder builder = VisitorInfo.builder();
 
         String name = getStringOrNull(options, "name", "visitorInfo");
         if (name != null) {
             builder = builder.withName(name);
+            anyValuesWereSet = true;
         }
         String email = getStringOrNull(options, "email", "visitorInfo");
         if (email != null) {
             builder = builder.withEmail(email);
+            anyValuesWereSet = true;
         }
         String phone = getStringOrNull(options, "phone", "visitorInfo");
         if (phone != null) {
             builder = builder.withPhoneNumber(phone);
+            anyValuesWereSet = true;
         }
 
-        visitorInfo = builder.build();
+        VisitorInfo visitorInfo = builder.build();
 
         if (Chat.INSTANCE.providers() == null) {
             Log.e(TAG,
                     "Zendesk Internals are undefined -- did you forget to call RNZendeskModule.init(<account_key>)?");
-            return;
+            return false;
         }
 
-        profileProvider = Chat.INSTANCE.providers().profileProvider();
-        profileProvider.setVisitorInfo(visitorInfo, null);
+        Chat.INSTANCE.providers().profileProvider().setVisitorInfo(visitorInfo, null);
+
+        return anyValuesWereSet;
     }
 
     @ReactMethod
@@ -204,6 +220,14 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
                 .withEmailFieldStatus(getFieldStatusOrDefault(options, "email", defaultValue))
                 .withPhoneFieldStatus(getFieldStatusOrDefault(options, "phone", defaultValue))
                 .withDepartmentFieldStatus(getFieldStatusOrDefault(options, "department", defaultValue));
+    }
+    // Produces a ReadableMap suitable for passing to setVisitorInfo that only has the fields that won't be asked by the preChatForm
+    private ReadableMap hiddenVisitorInfoData(ReadableMap allVisitorInfo, ReadableMap preChatFormOptions) {
+        WritableNativeMap output = new WritableNativeMap();
+        selectVisitorInfoFieldIfPreChatFormHidden("email", output, allVisitorInfo, preChatFormOptions);
+        selectVisitorInfoFieldIfPreChatFormHidden("name", output, allVisitorInfo, preChatFormOptions);
+        selectVisitorInfoFieldIfPreChatFormHidden("phone", output, allVisitorInfo, preChatFormOptions);
+        return output;
     }
 
     private void loadTags(ReadableMap options) {
@@ -260,16 +284,19 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
                     "Zendesk Internals are undefined -- did you forget to call RNZendeskModule.init(<account_key>)?");
             return;
         }
-        setVisitorInfo(options);
-        setupObserver();
+        pendingVisitorInfo = null;
+        boolean didSetVisitorInfo = _setVisitorInfo(options);
 
         ReadableMap flagHash = RNZendeskChatModule.getReadableMap(options, "behaviorFlags", "startChat");
+
         boolean showPreChatForm = getBooleanOrDefault(flagHash, "showPreChatForm", "startChat(behaviorFlags)", true);
+        boolean needsToSetVisitorInfoAfterChatStart = showPreChatForm && didSetVisitorInfo;
 
         ChatConfiguration.Builder chatBuilder = loadBehaviorFlags(ChatConfiguration.builder(), flagHash);
         if (showPreChatForm) {
-            chatBuilder = loadPreChatFormConfiguration(chatBuilder,
-                    getReadableMap(options, "preChatFormOptions", "startChat"));
+            ReadableMap preChatFormOptions = getReadableMap(options, "preChatFormOptions", "startChat");
+            chatBuilder = loadPreChatFormConfiguration(chatBuilder, preChatFormOptions);
+            pendingVisitorInfo = hiddenVisitorInfoData(options, preChatFormOptions);
         }
         ChatConfiguration chatConfig = chatBuilder.build();
 
@@ -282,6 +309,10 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
 
         MessagingConfiguration.Builder messagingBuilder = loadBotSettings(
                 getReadableMap(options, "messagingOptions", "startChat"), MessagingActivity.builder());
+
+        if (needsToSetVisitorInfoAfterChatStart) {
+            setupChatStartObserverToSetVisitorInfo();
+        }
 
         Activity activity = getCurrentActivity();
         if (activity != null) {
@@ -300,21 +331,24 @@ public class RNZendeskChatModule extends ReactContextBaseJavaModule {
         }
     }
     
-    public void setupObserver(){
-        final ObservationScope observationScope = new ObservationScope();
+    // https://support.zendesk.com/hc/en-us/articles/360055343673
+    public void setupChatStartObserverToSetVisitorInfo(){
+        // Create a temporary observation scope until the chat is started.
+        observationScope = new ObservationScope();
         Chat.INSTANCE.providers().chatProvider().observeChatState(observationScope, new Observer<ChatState>() {
             @Override
             public void update(ChatState chatState) {
                 ChatSessionStatus chatStatus = chatState.getChatSessionStatus();
                 // Status achieved after the PreChatForm is completed
                 if (chatStatus == ChatSessionStatus.STARTED) {
-                    // Update the information MID chat here. All info but Department can be updated
-                    if (!visitorSet) {
-                        // Add here the code to set the visitor info - visitorInfo would be a VisitorInfo type variable containing all the information to set
-                        profileProvider.setVisitorInfo(visitorInfo, null);
-                        visitorSet = true;
-                    }
+                    observationScope.cancel(); // Once the chat is started disable the observation
+                    observationScope = null; // Clean things up to avoid confusion.
+                    if (pendingVisitorInfo == null) { return; }
 
+                    // Update the information MID chat here. All info but Department can be updated
+                    // Add here the code to set the selected visitor info *after* the preChatForm is complete
+                    _setVisitorInfo(pendingVisitorInfo);
+                    pendingVisitorInfo = null;
                 } else {
                     // There are few other statuses that you can observe but they are unused in this example
                     Log.d(TAG, "[observerSetup] - ChatSessionUpdate -> (unused) status : " + chatStatus.toString());


### PR DESCRIPTION
Includes the changes from #82 

Changes:
- Adds some documentation
- Android: Changes the logic to only conditionally re-apply `VisitorInfo` after ChatStart *if it's needed*.
- Android: Removes some module-scope globals in favor of more temporary objects.