### PR TITLE
fix: added import to fix compilation error

### DIFF
--- a/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
+++ b/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java
@@ -1,6 +1,7 @@
 package com.taskrabbit.zendesk;
 
 import android.app.Activity;
+import android.content.pm.ApplicationInfo;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
This fix the following compilation error I have on the release/0.4.1 branch:
/Users/my-user/work/my-app/node_modules/react-native-zendesk-chat/android/src/main/java/com/taskrabbit/zendesk/RNZendeskChatModule.java:146: error: cannot find symbol
            & ApplicationInfo.FLAG_DEBUGGABLE) == 0)) {
              ^
  symbol:   variable ApplicationInfo
  location: class RNZendeskChatModule