### PR TITLE
Use same init wrapper on iOS as Android to handle optional param

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,15 @@
-import { NativeModules, Platform } from "react-native";
+import { NativeModules } from "react-native";
 
 const RNZendeskChatModule = NativeModules.RNZendeskChatModule;
 
-Platform.select({
-	default: () => {
-		return;
-	},
-	android: () => {
-		// react-native android doesn't support Java method overloading
-		// So this code implements the init method but makes sure to call
-		//  the right Java Code making sure there's a value for each parameter
-		// Reference: https://github.com/facebook/react-native/blob/07d090dbc6c46b8f3760dbd25dbe0540c18cb3f3/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java#L85-L86
-		RNZendeskChatModule.init = (key, appId) => {
-			return RNZendeskChatModule._initWith2Args(key, appId || null);
-		};
-	},
-})();
+// react-native doesn't support method overloading for Java or Objective-C
+// So this code implements the init method but makes sure to
+// always call it with two defined parameters, passing null for the second as needed
+// Reference: https://github.com/facebook/react-native/blob/07d090dbc6c46b8f3760dbd25dbe0540c18cb3f3/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java#L85-L86
+
+RNZendeskChatModule.init = (key, appId) => {
+	return RNZendeskChatModule._initWith2Args(key, appId || null);
+};
 
 /**
  * TypeScript Documentation for this Module describes the available methods & parameters

--- a/ios/RNZendeskChatModule.m
+++ b/ios/RNZendeskChatModule.m
@@ -187,7 +187,7 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
 	[RCTPresentedViewController() dismissViewControllerAnimated:YES completion:nil];
 }
 
-RCT_EXPORT_METHOD(init:(NSString *)zenDeskKey appId:(NSString *)appId) {
+RCT_EXPORT_METHOD(_initWith2Args:(NSString *)zenDeskKey appId:(NSString *)appId) {
 	if (appId) {
 		[ZDKChat initializeWithAccountKey:zenDeskKey appId:appId queue:dispatch_get_main_queue()];
 	} else {


### PR DESCRIPTION
@fbartho per your suggestion iOS now matches Android and the Platform-specific override is no longer needed. This change fixed the error for me on iOS.